### PR TITLE
Updates header content from "Berlin" to "online"

### DIFF
--- a/_data/header.yml
+++ b/_data/header.yml
@@ -1,7 +1,7 @@
 ---
 title: Solidity Summit
-date: 29+30 April 2020<br>Online
-subtitle: Two-day, friendly-sized single-track event with talks and workshops
+date: 29+30 April 2020<br>Virtual
+subtitle: Two-day, friendly-sized interactive online event with talks and workshops
 description: |
    The Solidity team is organizing a language summit to gather people involved and interested in the Solidity language, 
    the ecosystem and tooling around it. The intent is to have useful discussions that result in improvement proposals leading to actual implementations.

--- a/_data/header.yml
+++ b/_data/header.yml
@@ -1,9 +1,9 @@
 ---
 title: Solidity Summit
-date: 29+30 April 2020<br>Berlin
+date: 29+30 April 2020<br>Online
 subtitle: Two-day, friendly-sized single-track event with talks and workshops
 description: |
-   The Solidity team is organizing a language summit in Berlin to gather people involved and interested in the Solidity language, 
+   The Solidity team is organizing a language summit to gather people involved and interested in the Solidity language, 
    the ecosystem and tooling around it. The intent is to have useful discussions that result in improvement proposals leading to actual implementations.
    In particular, this event should help increase the amount of communication between teams working on similar 
-   topics or on topics that build on top of each other and identify needs for the smart contract ecosystem for Ethereum.
+   topics or on topics that build on top of each other and identify needs for the smart contract ecosystem for Ethereum. The event will be hosted online.


### PR DESCRIPTION
I'm currently updating the website to exclude  the location Berlin and make it more explicit that the event is 
a) definitely going to take place, just in a changed setup (currently it sounds a little vague)
b) will take place online, with more detailed information to follow shortly. 